### PR TITLE
feat(editor): commands (add/remove/move/changeType/editKeys) + undo/r…

### DIFF
--- a/apps/mobile/lib/editor/editor_commands_impl.dart
+++ b/apps/mobile/lib/editor/editor_commands_impl.dart
@@ -1,0 +1,140 @@
+import 'models.dart';
+
+/// 不変なユーティリティ
+Timeline _clone(Timeline src) => List<TimelineEvent>.from(src);
+
+int _idxById(Timeline list, String id) =>
+    list.indexWhere((e) => e.id == id);
+
+TimelineEvent _requireById(Timeline list, String id) {
+  final i = _idxById(list, id);
+  if (i < 0) {
+    throw StateError('event not found: $id');
+  }
+  return list[i];
+}
+
+/// 変更は純関数（EditorState -> EditorState）として定義
+typedef EditorOperation = EditorState Function(EditorState s);
+
+class EditorOps {
+  /// 追加：ID重複はエラー
+  static EditorOperation add(TimelineEvent ev, {bool select = true}) {
+    return (s) {
+      final list = _clone(s.events);
+      if (_idxById(list, ev.id) >= 0) {
+        throw StateError('event already exists: ${ev.id}');
+      }
+      list.add(ev);
+      return s.copyWith(
+        events: list,
+        selectedId: select ? ev.id : s.selectedId,
+      );
+    };
+  }
+
+  /// 削除：存在しなければエラー
+  static EditorOperation remove(String id) {
+    return (s) {
+      final list = _clone(s.events);
+      final i = _idxById(list, id);
+      if (i < 0) throw StateError('event not found: $id');
+      list.removeAt(i);
+      final sel = s.selectedId == id ? null : s.selectedId;
+      return s.copyWith(events: list, selectedId: sel);
+    };
+  }
+
+  /// 時間移動：start < end の検証あり
+  static EditorOperation move(String id, {required int startMs, required int endMs}) {
+    assert(startMs < endMs, 'startMs must be < endMs');
+    return (s) {
+      final list = _clone(s.events);
+      final i = _idxById(list, id);
+      if (i < 0) throw StateError('event not found: $id');
+      final old = list[i];
+      list[i] = old.copyWith(startMs: startMs, endMs: endMs);
+      return s.copyWith(events: list);
+    };
+  }
+
+  /// 種別変更
+  static EditorOperation changeType(String id, EventType type) {
+    return (s) {
+      final list = _clone(s.events);
+      final i = _idxById(list, id);
+      if (i < 0) throw StateError('event not found: $id');
+      final old = list[i];
+      list[i] = old.copyWith(type: type);
+      return s.copyWith(events: list);
+    };
+  }
+
+  /// keys をパッチ（merge=true ならマージ、false なら置換）
+  /// removeNulls=true の場合、value=null を削除扱いにする
+  static EditorOperation editKeys(
+    String id,
+    Map<String, Object?> patch, {
+    bool merge = true,
+    bool removeNulls = true,
+  }) {
+    return (s) {
+      final list = _clone(s.events);
+      final i = _idxById(list, id);
+      if (i < 0) throw StateError('event not found: $id');
+
+      Map<String, Object?> next;
+      if (merge) {
+        next = Map<String, Object?>.from(list[i].keys);
+        patch.forEach((k, v) {
+          if (removeNulls && v == null) {
+            next.remove(k);
+          } else {
+            next[k] = v;
+          }
+        });
+      } else {
+        next = Map<String, Object?>.from(patch);
+        if (removeNulls) {
+          next.removeWhere((_, v) => v == null);
+        }
+      }
+
+      list[i] = list[i].copyWith(keys: next);
+      return s.copyWith(events: list);
+    };
+  }
+}
+
+/// 超シンプルな Undo/Redo コントローラ（スナップショット方式）
+class EditorController {
+  EditorState state;
+  final List<EditorState> _undo = [];
+  final List<EditorState> _redo = [];
+
+  EditorController({EditorState? initial})
+      : state = initial ?? const EditorState();
+
+  void apply(EditorOperation op) {
+    _undo.add(state);
+    state = op(state);
+    _redo.clear();
+  }
+
+  bool canUndo() => _undo.isNotEmpty;
+  bool canRedo() => _redo.isNotEmpty;
+
+  bool undo() {
+    if (_undo.isEmpty) return false;
+    _redo.add(state);
+    state = _undo.removeLast();
+    return true;
+  }
+
+  bool redo() {
+    if (_redo.isEmpty) return false;
+    _undo.add(state);
+    state = _redo.removeLast();
+    return true;
+  }
+}

--- a/apps/mobile/lib/editor/models.dart
+++ b/apps/mobile/lib/editor/models.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/foundation.dart';
+
+/// エディタ内のイベント種別（最小セット）
+enum EventType { text, sticker, shape, subtitle }
+
+/// タイムライン上のイベント（最小構成）
+@immutable
+class TimelineEvent {
+  final String id;            // 一意ID
+  final EventType type;       // 種別
+  final int startMs;          // 開始（ms）
+  final int endMs;            // 終了（ms）[startMs < endMs]
+  final Map<String, Object?> keys; // 任意の属性（位置/サイズ/色など）
+
+  const TimelineEvent({
+    required this.id,
+    required this.type,
+    required this.startMs,
+    required this.endMs,
+    this.keys = const {},
+  }) : assert(startMs < endMs, 'startMs must be < endMs');
+
+  int get durationMs => endMs - startMs;
+
+  TimelineEvent copyWith({
+    String? id,
+    EventType? type,
+    int? startMs,
+    int? endMs,
+    Map<String, Object?>? keys,
+  }) {
+    return TimelineEvent(
+      id: id ?? this.id,
+      type: type ?? this.type,
+      startMs: startMs ?? this.startMs,
+      endMs: endMs ?? this.endMs,
+      keys: keys ?? this.keys,
+    );
+  }
+}
+
+/// 単純なタイムライン表現（必要に応じてクラス化予定）
+typedef Timeline = List<TimelineEvent>;
+
+/// エディタ全体の状態（最小）
+@immutable
+class EditorState {
+  final Timeline events;
+  final String? selectedId;
+
+  const EditorState({this.events = const [], this.selectedId});
+
+  EditorState copyWith({Timeline? events, String? selectedId}) {
+    return EditorState(
+      events: events ?? this.events,
+      selectedId: selectedId ?? this.selectedId,
+    );
+  }
+}

--- a/apps/mobile/lib/editor/models.dart
+++ b/apps/mobile/lib/editor/models.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/foundation.dart';
+import 'package:meta/meta.dart';
 
 /// エディタ内のイベント種別（最小セット）
 enum EventType { text, sticker, shape, subtitle }
@@ -57,3 +57,4 @@ class EditorState {
     );
   }
 }
+

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -154,7 +154,7 @@ packages:
     source: hosted
     version: "0.12.17"
   meta:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: meta
       sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,4 +1,4 @@
-﻿name: fokis_core
+name: fokis_core
 description: Core modules and tests for Fokis (P1).
 version: 0.1.0
 environment:
@@ -7,3 +7,5 @@ environment:
 # lib/ や tools/ をそのまま使う想定。依存は最小に。
 dev_dependencies:
   test: ^1.25.0
+dependencies:
+  meta: ^1.17.0

--- a/test/editor_commands_test.dart
+++ b/test/editor_commands_test.dart
@@ -1,0 +1,57 @@
+import 'package:test/test.dart';
+import '../apps/mobile/lib/editor/models.dart';
+import '../apps/mobile/lib/editor/editor_commands_impl.dart';
+
+void main() {
+  test('EditorOps basic ops + undo/redo', () {
+    final ctrl = EditorController();
+
+    // add
+    final e1 = TimelineEvent(
+      id: 'e1',
+      type: EventType.text,
+      startMs: 0,
+      endMs: 1000,
+      keys: const {'x': 0, 'y': 0},
+    );
+    ctrl.apply(EditorOps.add(e1));
+    expect(ctrl.state.events.length, 1);
+    expect(ctrl.state.selectedId, 'e1');
+
+    // move
+    ctrl.apply(EditorOps.move('e1', startMs: 100, endMs: 900));
+    expect(ctrl.state.events.first.startMs, 100);
+
+    // changeType
+    ctrl.apply(EditorOps.changeType('e1', EventType.sticker));
+    expect(ctrl.state.events.first.type, EventType.sticker);
+
+    // editKeys (merge + removeNulls)
+    ctrl.apply(EditorOps.editKeys('e1', {'x': 10, 'y': null, 'color': '#fff'}));
+    final k = ctrl.state.events.first.keys;
+    expect(k.containsKey('y'), isFalse);
+    expect(k['x'], 10);
+    expect(k['color'], '#fff');
+
+    // undo / redo
+    expect(ctrl.canUndo(), isTrue);
+    ctrl.undo(); // undo editKeys
+    expect(ctrl.state.events.first.keys.containsKey('color'), isFalse);
+    ctrl.redo();
+    expect(ctrl.state.events.first.keys['color'], '#fff');
+
+    // remove
+    ctrl.apply(EditorOps.remove('e1'));
+    expect(ctrl.state.events, isEmpty);
+    ctrl.undo(); // back
+    expect(ctrl.state.events.length, 1);
+  });
+
+  test('duplicate/add & notfound/move throw', () {
+    final ctrl = EditorController();
+    final e = TimelineEvent(id: 'a', type: EventType.text, startMs: 0, endMs: 10);
+    ctrl.apply(EditorOps.add(e));
+    expect(() => ctrl.apply(EditorOps.add(e)), throwsStateError);
+    expect(() => ctrl.apply(EditorOps.move('nope', startMs: 0, endMs: 1)), throwsStateError);
+  });
+}


### PR DESCRIPTION
…edo + tests

## 概要
- 対応: T? / R? / S? など

## 変更点
-

## テスト
- `dart test` 緑

## チェック
- [ ] 例外分岐（保存）変更加えていない / 加えた場合は契約テスト更新済み
- [ ] 競合ResolverのUIはflagでガード
