### PR TITLE
feat(conflict): add DiffSummary (compare/apply) with unit tests

### DIFF
--- a/apps/mobile/lib/conflict/conflict_model.dart
+++ b/apps/mobile/lib/conflict/conflict_model.dart
@@ -1,0 +1,84 @@
+import "package:collection/collection.dart";
+import "../editor/models.dart";
+
+enum DiffKind { add, remove, change }
+
+class DiffEntry {
+  final String id;
+  final DiffKind kind;
+  final TimelineEvent? a; // 旧
+  final TimelineEvent? b; // 新
+  const DiffEntry({required this.id, required this.kind, this.a, this.b});
+}
+
+class DiffSummary {
+  final List<DiffEntry> entries;
+  const DiffSummary(this.entries);
+
+  static final _mapEq = const DeepCollectionEquality().equals;
+
+  static bool _eventEquals(TimelineEvent x, TimelineEvent y) {
+    return x.id == y.id &&
+        x.type == y.type &&
+        x.startMs == y.startMs &&
+        x.endMs == y.endMs &&
+        _mapEq(x.keys, y.keys);
+  }
+
+  /// タイムライン A→B の差分をイベント粒度で計算
+  static DiffSummary compare(Timeline a, Timeline b) {
+    final ma = {for (final e in a) e.id: e};
+    final mb = {for (final e in b) e.id: e};
+    final ids = {...ma.keys, ...mb.keys}.toList()..sort();
+    final list = <DiffEntry>[];
+
+    for (final id in ids) {
+      final ea = ma[id];
+      final eb = mb[id];
+      if (ea != null && eb == null) {
+        list.add(DiffEntry(id: id, kind: DiffKind.remove, a: ea));
+      } else if (ea == null && eb != null) {
+        list.add(DiffEntry(id: id, kind: DiffKind.add, b: eb));
+      } else if (ea != null && eb != null && !_eventEquals(ea, eb)) {
+        list.add(DiffEntry(id: id, kind: DiffKind.change, a: ea, b: eb));
+      }
+    }
+    return DiffSummary(list);
+  }
+
+  /// 採否マップで B 案を適用（true= B を採用 / false = Aを維持）
+  ///
+  /// - add:   true で追加、false で追加しない
+  /// - remove:true で削除、false で残す
+  /// - change:true で置換、false で据え置き
+  static Timeline apply({
+    required Timeline baseA,
+    required Timeline targetB,
+    required Map<String, bool> acceptBById,
+  }) {
+    final ma = {for (final e in baseA) e.id: e};
+    final mb = {for (final e in targetB) e.id: e};
+    final diff = compare(baseA, targetB);
+
+    for (final d in diff.entries) {
+      final accept = acceptBById[d.id] ?? false;
+      switch (d.kind) {
+        case DiffKind.add:
+          if (accept && d.b != null) ma[d.id] = d.b!;
+          break;
+        case DiffKind.remove:
+          if (accept) ma.remove(d.id);
+          break;
+        case DiffKind.change:
+          if (accept && d.b != null) {
+            ma[d.id] = d.b!;
+          } // accept=false なら何もしない
+          break;
+      }
+    }
+    // 安定化のため ID ソート
+    final out = ma.values.toList()
+      ..sort((x, y) => x.id.compareTo(y.id));
+    return out;
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -50,7 +50,7 @@ packages:
     source: hosted
     version: "0.2.0"
   collection:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: collection
       sha256: "2f5709ae4d3d59dd8f7cd309b4e023046b57d8a6c82130785d2b0e5868084e76"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,3 +9,4 @@ dev_dependencies:
   test: ^1.25.0
 dependencies:
   meta: ^1.17.0
+  collection: ^1.19.1

--- a/test/conflict_model_test.dart
+++ b/test/conflict_model_test.dart
@@ -1,0 +1,44 @@
+import "package:test/test.dart";
+import "../apps/mobile/lib/editor/models.dart";
+import "../apps/mobile/lib/conflict/conflict_model.dart";
+
+TimelineEvent ev(String id, EventType t, int s, int e, [Map<String,Object?> k=const {}]) =>
+  TimelineEvent(id: id, type: t, startMs: s, endMs: e, keys: k);
+
+void main() {
+  group("DiffSummary.compare & apply", () {
+    test("add/remove/change を検出して採否適用できる", () {
+      final a = <Timeline>[
+        // A: e1(text), e2(sticker)
+        [
+          ev("e1", EventType.text, 0, 10, {"x":1}),
+          ev("e2", EventType.sticker, 10, 20),
+        ],
+        // B: e1 を type 変更(text→sticker), e2 を削除, e3 を追加
+        [
+          ev("e1", EventType.sticker, 0, 10, {"x":1}), // change
+          ev("e3", EventType.text, 30, 40),            // add
+        ],
+      ];
+
+      final diff = DiffSummary.compare(a[0], a[1]);
+      expect(diff.entries.map((d)=>d.kind).toSet(),
+          containsAll({DiffKind.add, DiffKind.remove, DiffKind.change}));
+
+      // 採否: e1= B を採用, e2= A を維持(削除拒否), e3= B を採用
+      final merged = DiffSummary.apply(
+        baseA: a[0],
+        targetB: a[1],
+        acceptBById: {"e1": true, "e2": false, "e3": true},
+      );
+
+      // 結果: e1(sticker), e2(sticker) 残る, e3(add) 入る
+      expect(merged.length, 3);
+      merged.sort((x,y)=>x.id.compareTo(y.id));
+      final m = {for (final e in merged) e.id: e};
+      expect(m["e1"]!.type, EventType.sticker);
+      expect(m["e2"]!.type, EventType.sticker);
+      expect(m.containsKey("e3"), isTrue);
+    });
+  });
+}


### PR DESCRIPTION
## 概要
- 対応: T? / R? / S? など

## 変更点
-

## テスト
- `dart test` 緑

## チェック
- [ ] 例外分岐（保存）変更加えていない / 加えた場合は契約テスト更新済み
- [ ] 競合ResolverのUIはflagでガード
